### PR TITLE
Add 'GitHub Skills' activity to activities list

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -39,6 +39,12 @@ activities = {
         "max_participants": 30,
         "participants": ["john@mergington.edu", "olivia@mergington.edu"]
     },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.",
+        "schedule": "Thursdays, 4:00 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
+    },
     "Soccer Team": {
         "description": "Join the school soccer team and compete in matches",
         "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",


### PR DESCRIPTION
This pull request adds the new 'GitHub Skills' activity to the list of available extracurricular activities, as requested in issue #6. Students can now view and register for this new activity via the web interface.

- Activity description: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program.
- Schedule: Thursdays, 4:00 PM - 5:00 PM
- Max participants: 25

Closes #6.